### PR TITLE
Liam / Print statement for CPU temperatures

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ../exporter:/usr/src/app/exporter
     working_dir: /usr/src/app
-    command: python3 start_exporter.py
+    command: python3 -u start_exporter.py
     networks:
       - systel-subnet
 

--- a/exporter/collectors/cpu.py
+++ b/exporter/collectors/cpu.py
@@ -30,6 +30,7 @@ class CPUCollector:
         @mccooeyc11
         Returns the CPU temperature in degrees Celsius.        
         """
+        print(psutil.sensors_temperatures()) ## Debugging Purposes
         if not psutil.sensors_temperatures():
             return None
         else:


### PR DESCRIPTION
Single commit PR to allow for CPU temperatures tuple to be seen for debugging purposes.
- Modified docker-compose.yml to run the python exporter unbuffered to allow print statements to show. The extra argument allows for this.
- Added a print statement in cpu.py to show available temperature sensors.
- Only tested with docker not Azure.
