### PR TITLE
Leila / CPU utilization by logical & physical core #86

### DIFF
--- a/exporter/collectors/cpu.py
+++ b/exporter/collectors/cpu.py
@@ -39,20 +39,6 @@ class CPUCollector:
             else:
                 return None
 
-    def __str__(self) -> str:
-        """
-        @mccooeyc11
-        Returns to string representation of all CPU metrics.        
-        """
-        utilization = self.get_utilization()
-        frequency = self.get_frequency()
-        temp = self.get_temperature()
-        if temp:
-            temp = temp.__str__()
-            return f"CPU utilization: {utilization}%\n CPU frequency: {frequency}MHz\n CPU temperature: {temp}°C\n"
-        else:
-            return f"CPU utilization: {utilization}%\n CPU frequency: {frequency}MHz\n CPU temperature: not available\n"
-
     def get_utilization_by_core(self):
         """
         @l3331l4
@@ -66,3 +52,17 @@ class CPUCollector:
             core_utilizations.append(core_utilization)
 
         return cpu_percent, core_utilizations
+
+    def __str__(self) -> str:
+        """
+        @mccooeyc11
+        Returns to string representation of all CPU metrics.        
+        """
+        utilization = self.get_utilization()
+        frequency = self.get_frequency()
+        temp = self.get_temperature()
+        if temp:
+            temp = temp.__str__()
+            return f"CPU utilization: {utilization}%\n CPU frequency: {frequency}MHz\n CPU temperature: {temp}°C\n"
+        else:
+            return f"CPU utilization: {utilization}%\n CPU frequency: {frequency}MHz\n CPU temperature: not available\n"

--- a/exporter/collectors/cpu.py
+++ b/exporter/collectors/cpu.py
@@ -53,3 +53,16 @@ class CPUCollector:
         else:
             return f"CPU utilization: {utilization}%\n CPU frequency: {frequency}MHz\n CPU temperature: not available\n"
 
+    def get_utilization_by_core(self):
+        """
+        @l3331l4
+        Returns a list of CPU utilization percentages for each logical core and physical core.
+        """    
+        cpu_percent = psutil.cpu_percent(percpu=True)
+        logical_processors_per_core = psutil.cpu_count(logical=True) // psutil.cpu_count(logical=False)
+        core_utilizations = []  
+        for i in range(0, len(cpu_percent), logical_processors_per_core):
+            core_utilization = sum(cpu_percent[i:i+logical_processors_per_core]) 
+            core_utilizations.append(core_utilization)
+
+        return cpu_percent, core_utilizations

--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -25,7 +25,16 @@ def export_metrics(port=8000):
         set_gauge(cpu_utilization_gauge, cpu_collector.get_utilization())
         set_gauge(cpu_frequency_gauge, cpu_collector.get_frequency())
         set_gauge(cpu_temperature_gauge, cpu_collector.get_temperature())
-
+        utilization_by_logical_core, utilization_by_physical_core = cpu_collector.get_utilization_by_core()
+        num_logical_cores = len(utilization_by_logical_core)
+        num_physical_cores = len(utilization_by_physical_core)
+        for core in range(num_logical_cores):
+            logical_core_utilization = utilization_by_logical_core[core]
+            cpu_utilization_by_logical_core_gauge.labels(core=str(core)).set(logical_core_utilization)      
+        for core in range(num_physical_cores):
+            physical_core_utilization = utilization_by_physical_core[core]
+            cpu_utilization_by_physical_core_gauge.labels(core=str(core)).set(physical_core_utilization)        
+             
         set_gauge(ram_utilization_gauge, ram_collector.get_utilization())
         set_gauge(ram_memory_total_gauge, ram_collector.get_memory_total())
         set_gauge(ram_memory_used_gauge,ram_collector.get_memory_used())

--- a/exporter/metrics.py
+++ b/exporter/metrics.py
@@ -3,6 +3,8 @@ from prometheus_client import Gauge
 cpu_utilization_gauge = Gauge("stagent_cpu_utilization_overall_percentage", "System-wide CPU utilization as a percentage")
 cpu_frequency_gauge = Gauge("stagent_cpu_frequency_current_mhz", "CPU frequency in MHz")
 cpu_temperature_gauge = Gauge("stagent_cpu_coretemp_sensor_1_celsius", "Core temperature from Sensor 1 in Celsius")
+cpu_utilization_by_logical_core_gauge = Gauge("stagent_cpu_utilization_by_logical_core", "CPU utilization by logical core as a percentage", ["core"])
+cpu_utilization_by_physical_core_gauge = Gauge("stagent_cpu_utilization_by_physical_core", "CPU utilization by physical core as a percentage", ["core"])
 
 network_get_traffic_in_gauge = Gauge("stagent_traffic_in_mbs", "NETWORK inbound traffic in Mb/s")
 network_get_traffic_out_gauge = Gauge("stagent_traffic_out_mbs", "NETWORK outbound traffic in Mb/s")

--- a/tests/exporter/collectors/test_cpu.py
+++ b/tests/exporter/collectors/test_cpu.py
@@ -49,6 +49,15 @@ class TestCPUCollector(unittest.TestCase):
         self.assertTrue('MHz\n' in output_str)
         self.assertTrue('CPU temperature: ' in output_str)
 
+    def test_get_utilization_by_core(self): 
+        """
+        @l3331l4
+        Test whether CPU utilization by core is within an acceptable range
+        """
+        cpu_collector = CPUCollector()
+        cpu_percent, core_utilizations = cpu_collector.get_utilization_by_core()
+        self.assertTrue(all(0 <= util <= 100 for util in cpu_percent))
+        self.assertTrue(all(0 <= util <= 100 for util in core_utilizations))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a get_utilization_by_core method in cpu.py which returns a list of percentages for both logical and physical cores and exporting them as separate gauges so there's more flexibility over how to read the data.

Closes #86.